### PR TITLE
Reset db command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ You can now quit the shell with `\q`.
 Resetting Your Database
 ==============
     python manage.py reset_db --router=default
+    python manage.py syncdb
 This will delete all your current data and update the db to have the new fields in the models.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,5 @@ You can now quit the shell with `\q`.
 
 Reseting Your Database
 ==============
-psql -d tbg_db
-drop table <table name> cascade;
-\q
-python manage.py syncdb
+    python manage.py reset_db --router=default
+This will delete all your current data and update the db to have the new fields in the models.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,12 @@ Django==1.4.4
 argparse==1.2.1
 distribute==0.6.31
 dj-database-url==0.2.1
+django-extensions==1.1.1
 gevent==0.13.8
 gevent-socketio==0.3.5-rc2
 gevent-websocket==0.3.6
 greenlet==0.4.0
 gunicorn==0.16.1
 psycopg2==2.4.6
+six==1.3.0
 wsgiref==0.1.2

--- a/the_game_bazaar/settings.py
+++ b/the_game_bazaar/settings.py
@@ -125,6 +125,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_extensions',
     'the_game_bazaar',
     'game',
     'gmap',


### PR DESCRIPTION
Added the 'django-extensions' app which as a 'reset_db' command so we don't have to manually be dropping tables and stuff. You'll need to pip install requirements again after this request gets merged in

@kfang 
