### PR TITLE
Improve rest api

### DIFF
--- a/editor/static/editor/js/editor.js
+++ b/editor/static/editor/js/editor.js
@@ -48,10 +48,14 @@ Editor.prototype.setEditingMap = function(map) {
 
 Editor.prototype.saveMap = function() {
     var self = this;
-    data = {map_id : this.map.id, map_data : JSON.stringify(this.map.toJSON())};
+    var map_id = this.map.id;
+    if (!map_id) {
+        map_id = '';
+    }
+    data = {map_data : JSON.stringify(this.map.toJSON())};
     $.ajax({
         type: "POST",
-        url: '/map/',
+        url: '/map/' + this.map.id,
         data: data,
         success: function (response_json) {
             console.log("success", response_json);
@@ -71,8 +75,7 @@ Editor.prototype.loadMap = function(map_id) {
 
     $.ajax({
         type: "GET",
-        url: '/map/',
-        data: {map_id : map_id},
+        url: '/map/' + map_id,
         success: successCallback,
         dataType: 'json'
     });

--- a/editor/static/editor/js/editor.js
+++ b/editor/static/editor/js/editor.js
@@ -55,7 +55,7 @@ Editor.prototype.saveMap = function() {
     data = {map_data : JSON.stringify(this.map.toJSON())};
     $.ajax({
         type: "POST",
-        url: '/map/' + this.map.id,
+        url: '/map/' + map_id,
         data: data,
         success: function (response_json) {
             console.log("success", response_json);

--- a/game/forms.py
+++ b/game/forms.py
@@ -1,0 +1,6 @@
+# forms.py
+from django import forms
+
+
+class GameForm(forms.Form):
+    map_id = forms.IntegerField(required=True, min_value=0)

--- a/game/models.py
+++ b/game/models.py
@@ -25,6 +25,41 @@ class Game(models.Model):
     def get_games_in_state(state):
         return Game.objects.filter(state=state)
 
+    # Helper method: Adds a new Game entry into the db with the specified host
+    @staticmethod
+    def create_new_game(map_id, host):
+        theMap = Map.objects.get(pk=map_id)
+        # Create the players array (only the host at the moment)
+        players_json = [""] * theMap.num_players
+        players_json[0] = host.username
+
+        game = Game(map=theMap, players=json.dumps(players_json), state=Game.LOBBY)
+        game.save()
+        return game, players_json
+
+    # Helper Method: Returns (game object, [username, username, username], my_player_id)
+    @staticmethod
+    def add_user_to_game(game_id, user):
+        game = Game.objects.get(pk=game_id)
+
+        # Add this player to the player list for the game.
+        players_json = json.loads(game.players)
+        # If the user isn't already in the game, add them to it.
+        player_id = -1
+        for idx, username in enumerate(players_json):
+            # If the user is already in the game or there is an empty spot, put him there
+            if user.username == username or username == '':
+                players_json[idx] = user.username
+                player_id = idx
+                break
+
+        # TODO handle a user rejection gracefully
+        assert player_id != -1, "No empty slot for player " + user.username + " in json " + json.dumps(players_json)
+        game.players = json.dumps(players_json)
+        game.save()
+
+        return game, players_json, player_id
+
     def to_map(game):
         return {
             'players': json.loads(game.players),

--- a/game/sockets.py
+++ b/game/sockets.py
@@ -1,8 +1,10 @@
 from socketio.namespace import BaseNamespace
 from socketio.mixins import RoomsMixin, BroadcastMixin
+from lib.sdjango import namespace
 import time
 
 
+@namespace('/game')
 class GameNamespace(BaseNamespace, RoomsMixin, BroadcastMixin):
 
     def broadcast_to_room(self, room, event, *args):

--- a/game/static/game/js/game.js
+++ b/game/static/game/js/game.js
@@ -53,7 +53,7 @@ Game.prototype.init = function(gs_renderer) {
     this.gs_renderer = gs_renderer || new GSRenderer();
 };
 
-//This method gets called as soon 
+//This method gets called as soon
 Game.prototype.handleConnecting = function() {
     // DEBUG
     console.log("Connecting...");
@@ -178,13 +178,7 @@ Game.prototype.instantiateGameState = function() {
     this.gamestate = false;
     $.ajax({
         type: "GET",
-        url: "/map/",
-        data: {
-            "map_id": parseInt(this.map_id, 10)
-        },
-        headers: {
-            "X-CSRFToken": $.cookie('csrftoken')
-        },
+        url: "/map/" + parseInt(this.map_id, 10),
         success: function (data){
             if(data['success'] === true){
                 map_data_json = JSON.parse(data.map_data);

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from game import views
+from game.views import LobbiesView, GameView
 from game.models import Game
 from lib.models import Map
 from django.contrib.auth.models import User
@@ -30,16 +30,16 @@ class GameControllerTest(TestCase):
         self.aMap.save()
 
     def test_create_new_game(self):
-        game, players_json = views.create_new_game(self.aMap.id, self.user)
+        game, players_json = Game.create_new_game(self.aMap.id, self.user)
         self.assertEqual(len(players_json), 3)
         self.assertEqual(players_json[0], "hosting_player")
         pass
 
     def test_add_user_to_game(self):
-        game, _ = views.create_new_game(self.aMap.id, self.user)
+        game, _ = Game.create_new_game(self.aMap.id, self.user)
 
         # Perform the join logic
-        _, players_json, player_id = views.add_user_to_game(game.id, self.joiner)
+        _, players_json, player_id = Game.add_user_to_game(game.id, self.joiner)
 
         # Check a bunch of conditions
         self.assertEqual(len(players_json), 3)

--- a/game/urls.py
+++ b/game/urls.py
@@ -3,9 +3,11 @@ from game.views import LobbiesView, GameView
 
 urlpatterns = patterns(
     '',
+    # Route requests that go to /game/<gameid>
     url(r'(?P<gameid>.+)$',
         GameView.as_view(),
         name="game_view"),
+    # Route requests with no <gameid>
     url(r'$',
         LobbiesView.as_view(),
         name="lobbies_view")

--- a/game/urls.py
+++ b/game/urls.py
@@ -1,17 +1,13 @@
 from django.conf.urls import patterns, url
-from game import views
+from game.views import LobbiesView, GameView
 
+urlpatterns = patterns(
+    '',
+    url(r'(?P<gameid>.+)$',
+        GameView.as_view(),
+        name="game_view"),
+    url(r'$',
+        LobbiesView.as_view(),
+        name="lobbies_view")
 
-urlpatterns = patterns('',
-    url(r'host',
-        views.host_game,
-        name="host"),
-
-    url(r'join',
-        views.join_game,
-        name="join"),
-
-    url(r'',
-        views.socketio,
-        name="socketio"),
 )

--- a/game/views.py
+++ b/game/views.py
@@ -53,14 +53,14 @@ class LobbiesView(View):
 
 class GameView(View):
     """
-    Handles all requests that go to /game/#gameid
+    Handles all requests that go to /game/<gameid>
     """
 
     http_method_names = ['get', 'options']
 
-    # GET /game/#gameid
+    # GET /game/<gameid>
     def get(self, request, gameid):
-        """ Get the page for game #gameid and join the player to the game """
+        """ Get the page for game <gameid> and join the player to the game """
         try:
             gameid = int(gameid)
         except ValueError:

--- a/jasmine_testing/static/jasmine_testing/specs/EditorSpec.js
+++ b/jasmine_testing/static/jasmine_testing/specs/EditorSpec.js
@@ -77,14 +77,14 @@ describe("Map Editor", function() {
             });
         });
 
-        it("should POST to /map/ with map id and map data", function() {
+        it("should POST to /map/#mapid with map data", function() {
             editor.map.id = 10;
             editor.saveMap();
 
             var request = $.ajax.mostRecentCall.args[0];
-            expect(request.url).toBe('/map/');
+            expect(request.url).toBe('/map/10');
             expect(request.type).toBe('POST');
-            expect(request.data).toEqual({map_id: 10, map_data: JSON.stringify(editor.map.toJSON())});
+            expect(request.data).toEqual({map_data: JSON.stringify(editor.map.toJSON())});
         });
 
         it("should call setEditingMap with its own map", function() {
@@ -114,13 +114,12 @@ describe("Map Editor", function() {
                             ajax_params = params;
                     });
             });
-            it("should GET /map/ with map_id as a param", function() {
+            it("should GET /map/#mapid", function() {
                     editor.loadMap(10);
 
                     var request = $.ajax.mostRecentCall.args[0];
-                    expect(request.url).toBe('/map/');
+                    expect(request.url).toBe('/map/10');
                     expect(request.type).toBe('GET');
-                    expect(request.data).toEqual({map_id: 10});
             });
 
             it("should load a map it gets back", function() {

--- a/jasmine_testing/static/jasmine_testing/specs/EditorSpec.js
+++ b/jasmine_testing/static/jasmine_testing/specs/EditorSpec.js
@@ -77,7 +77,7 @@ describe("Map Editor", function() {
             });
         });
 
-        it("should POST to /map/#mapid with map data", function() {
+        it("should POST to /map/<mapid> with map data", function() {
             editor.map.id = 10;
             editor.saveMap();
 
@@ -114,7 +114,7 @@ describe("Map Editor", function() {
                             ajax_params = params;
                     });
             });
-            it("should GET /map/#mapid", function() {
+            it("should GET /map/<mapid>", function() {
                     editor.loadMap(10);
 
                     var request = $.ajax.mostRecentCall.args[0];

--- a/jasmine_testing/static/jasmine_testing/specs/GameSpec.js
+++ b/jasmine_testing/static/jasmine_testing/specs/GameSpec.js
@@ -133,14 +133,13 @@ describe("Game", function() {
         beforeEach(function() {
             game.map_id = 120;
         });
-        it("should make a GET request to /map/ with the map_id", function() {
+        it("should make a GET request to /map/#mapid", function() {
             spyOn($, 'ajax');
             game.instantiateGameState();
 
             var request = $.ajax.mostRecentCall.args[0];
-            expect(request.url).toBe('/map/');
+            expect(request.url).toBe('/map/120');
             expect(request.type).toBe('GET');
-            expect(request.data).toEqual({map_id: 120});
         });
 
         describe("on success", function() {

--- a/jasmine_testing/static/jasmine_testing/specs/GameSpec.js
+++ b/jasmine_testing/static/jasmine_testing/specs/GameSpec.js
@@ -133,7 +133,7 @@ describe("Game", function() {
         beforeEach(function() {
             game.map_id = 120;
         });
-        it("should make a GET request to /map/#mapid", function() {
+        it("should make a GET request to /map/<mapid>", function() {
             spyOn($, 'ajax');
             game.instantiateGameState();
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -1,0 +1,43 @@
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from re import compile
+
+
+def handle_empty(url):
+    if url == '':
+        return r'^$'
+    return url
+
+EXEMPT_URLS = [compile(handle_empty(settings.LOGIN_URL.lstrip('/')))]
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(handle_empty(expr)) for expr in settings.LOGIN_EXEMPT_URLS]
+
+
+class LoginRequiredMiddleware:
+    """
+    Middleware that requires a user to be authenticated to view any page other
+    than LOGIN_URL. Exemptions to this requirement can optionally be specified
+    in settings via a list of regular expressions in LOGIN_EXEMPT_URLS (which
+    you can copy from your urls.py).
+
+    Requires authentication middleware and template context processors to be
+    loaded. You'll get an error if they aren't.
+
+    The Login Required middleware requires authentication middleware to be
+    installed. Edit your MIDDLEWARE_CLASSES setting to insert
+    'django.contrib.auth.middleware.AuthenticationMiddleware'. If that doesn't
+    work, ensure your TEMPLATE_CONTEXT_PROCESSORS setting includes
+    'django.contrib.auth.context_processors.auth'.
+    """
+    def process_view(self, request, vfunc, vargs, vkwargs):
+        # No need to process URLs if user already logged in
+        if request.user.is_authenticated():
+            return None
+
+        path = request.path_info.lstrip('/')
+        if not any(m.match(path) for m in EXEMPT_URLS):
+            return login_required(function=vfunc, login_url=settings.LOGIN_URL, redirect_field_name=None)(request, *vargs, **vkwargs)
+
+        # Explicitly return None for all non-matching requests
+        return None

--- a/lib/models.py
+++ b/lib/models.py
@@ -9,12 +9,12 @@ class Map(models.Model):
     num_players = models.IntegerField()
     data = models.TextField()
     map_name = models.CharField(max_length=255)
-    created_at = models.DateTimeField(auto_now_add = True)
-    updated_at = models.DateTimeField(auto_now = True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def to_map(this_map):
         return {
-        	'id':this_map.id,
+            'id': this_map.id,
             'creator': this_map.creator.username,
             'max_players': this_map.num_players,
             'name': this_map.map_name,

--- a/lib/sdjango.py
+++ b/lib/sdjango.py
@@ -1,0 +1,70 @@
+import logging
+
+from socketio import socketio_manage
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.importlib import import_module
+
+# for Django 1.3 support
+try:
+    from django.conf.urls import patterns, url, include
+except ImportError:
+    from django.conf.urls.defaults import patterns, url, include
+
+
+SOCKETIO_NS = {}
+
+
+LOADING_SOCKETIO = False
+
+
+def autodiscover():
+    """
+    Auto-discover INSTALLED_APPS sockets.py modules and fail silently when
+    not present. NOTE: socketio_autodiscover was inspired/copied from
+    django.contrib.admin autodiscover
+    """
+    global LOADING_SOCKETIO
+    if LOADING_SOCKETIO:
+        return
+    LOADING_SOCKETIO = True
+
+    import imp
+    from django.conf import settings
+
+    for app in settings.INSTALLED_APPS:
+
+        try:
+            app_path = import_module(app).__path__
+        except AttributeError:
+            continue
+
+        try:
+            imp.find_module('sockets', app_path)
+        except ImportError:
+            continue
+
+        import_module("%s.sockets" % app)
+
+    LOADING_SOCKETIO = False
+
+
+class namespace(object):
+    def __init__(self, name=''):
+        self.name = name
+
+    def __call__(self, handler):
+        SOCKETIO_NS[self.name] = handler
+        return handler
+
+
+@csrf_exempt
+def socketio(request):
+    try:
+        socketio_manage(request.environ, SOCKETIO_NS, request)
+    except:
+        logging.getLogger("socketio").error("Exception while handling socketio connection", exc_info=True)
+    return HttpResponse("")
+
+
+urls = patterns("", (r'', socketio))

--- a/lib/templates/lib/navbar.html
+++ b/lib/templates/lib/navbar.html
@@ -2,17 +2,17 @@
     <div class="navbar-inner">
         <a href="/" class="brand">The Game Bazaar</a>
         <ul class="nav">
-            <li id="navbar-home"><a href="/">Home</a></li>
-            <li id="navbar-play"><a href="/play">Play</a></li>
-            <li id="navbar-edit"><a href="/edit">Edit</a></li>
+            <li id="navbar-home"><a href="{% url index %}">Home</a></li>
+            <li id="navbar-play"><a href="{% url lobbies_view %}">Play</a></li>
+            <li id="navbar-edit"><a href="{% url edit %}">Edit</a></li>
         </ul>
         {% if user.is_authenticated %}
             <ul class="nav pull-right">
                 <li id="fat-menu" class="dropdown">
                     <a href="#" id="drop3" role="button" class="dropdown-toggle" data-toggle="dropdown">{{ user.username }} <b class="caret"></b></a>
                     <ul class="dropdown-menu" role="menu" aria-labelledby="drop3">
-                        <li role="presentation"><a role="menuitem" tabindex="-1" href="/user/admin">Profile</a></li>
-                        <li role="presentation"><a role="menuitem" tabindex="-1" href="/user/history">History</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="{% url user_admin %}">Profile</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="{% url user_history %}">History</a></li>
                         <li role="presentation" class="divider"></li>
                         <li role="presentation"><a role="menuitem" tabindex="-1" href="" id="navbar-logout">logout
                         </a></li>

--- a/lib/tests.py
+++ b/lib/tests.py
@@ -28,24 +28,24 @@ class MapTester(TestCase):
     def make_GET(self, map_id=None):
         if map_id is None:
             map_id = Map.objects.all()[0].id
-        response = self.client.get(reverse("get_map"), {"map_id": map_id})
+        response = self.client.get(reverse("map_view", kwargs={'mapid': map_id}))
         return (response, json.loads(response.content))
 
     def make_POST(self, map_data, map_id=None):
         if map_id is None:
             map_id = Map.objects.all()[0].id
 
-        params = {'map_id': map_id, 'map_data': map_data}
-        response = self.client.post(reverse('get_map'), params)
+        params = {'map_data': map_data}
+        response = self.client.post(reverse('map_view', kwargs={'mapid': map_id}), params)
         return (response, json.loads(response.content))
 
 
 class MapGETTester(MapTester):
 
-    def test_get_map_data_is_string(self):
+    def test_map_view_data_is_string(self):
         self.make_GET()
 
-    def test_successfully_get_map(self):
+    def test_successfully_map_view(self):
         map_id = Map.objects.all()[0].id
         _, response_json = self.make_GET()
         self.assertTrue(response_json['success'])
@@ -61,7 +61,7 @@ class MapGETTester(MapTester):
         self.assertFalse(json["success"])
 
     def test_no_map_id_parameter(self):
-        response = self.client.get(reverse("get_map"), {})
+        response = self.client.get(reverse("new_map_view"), {})
         self.assertFalse(json.loads(response.content)['success'])
 
 
@@ -69,7 +69,7 @@ class MapPOSTTester(MapTester):
 
     def test_successfully_post_new_map(self):
         map_data = "{'players': [{'id':0,'units':[]}, {'id':1,'units':[]}]}"
-        response_json = json.loads(self.client.post(reverse("get_map"), {'map_data': map_data}).content)
+        response_json = json.loads(self.client.post(reverse("new_map_view"), {'map_data': map_data}).content)
         self.assertTrue(response_json["success"])
         self.assertEqual(map_data, Map.objects.get(id=response_json['map_id']).data)
         # import code

--- a/lib/urls.py
+++ b/lib/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import patterns, url
+from lib.views import MapView, NewMapView
+
+urlpatterns = patterns(
+    '',
+    url(r'(?P<mapid>.+)$',
+        MapView.as_view(),
+        name="map_view"),
+    url(r'$',
+        NewMapView.as_view(),
+        name="new_map_view"
+        )
+)

--- a/lib/views.py
+++ b/lib/views.py
@@ -13,7 +13,7 @@ def json_response(response_data):
 
 class MapView(View):
     """
-    Handles all requests that go to /map/#mapid
+    Handles all requests that go to /map/<mapid>
     """
 
     http_method_names = ['get', 'post', 'options']
@@ -23,6 +23,7 @@ class MapView(View):
     def dispatch(self, *args, **kwargs):
         return super(MapView, self).dispatch(*args, **kwargs)
 
+    # GET /map/<mapid>
     def get(self, request, mapid):
         try:
             mapid = int(mapid)
@@ -46,6 +47,7 @@ class MapView(View):
                 'reason': "No map exists with given map id!"
             })
 
+    # POST /map/<mapid>
     def post(self, request, mapid):
         try:
             mapid = int(mapid)
@@ -82,12 +84,14 @@ class NewMapView(View):
     def dispatch(self, *args, **kwargs):
         return super(NewMapView, self).dispatch(*args, **kwargs)
 
+    # GET /map/
     def get(self, request):
         return json_response({
             'success': False,
             'reason': "No map id supplied!"
         })
 
+    # POST /map/
     def post(self, request):
         creator = request.user
         num_players = 2  # uh oh

--- a/lib/views.py
+++ b/lib/views.py
@@ -2,72 +2,105 @@ from django.http import HttpResponse
 from django.utils import simplejson as json
 from django.views.decorators.csrf import csrf_exempt
 from lib.models import Map
-from django.contrib.auth.models import User
+from django.views.generic import View
 
-@csrf_exempt
-def get_map(request):
-    if request.method == 'GET':
-        if 'map_id' not in request.GET:
-            map_id = "";
-        else:
-            map_id = request.GET['map_id'];
+# from django.contrib.auth.models import User
 
-        if not map_id:
-            return HttpResponse(json.dumps({
-                'success': False,
-                'reason': "No map id supplied!"
-                }), mimetype='application/json')
 
+def json_response(response_data):
+    return HttpResponse(json.dumps(response_data), content_type="application/json")
+
+
+class MapView(View):
+    """
+    Handles all requests that go to /map/#mapid
+    """
+
+    http_method_names = ['get', 'post', 'options']
+
+    # This is how you add a decorator to a class-based view
+    @csrf_exempt
+    def dispatch(self, *args, **kwargs):
+        return super(MapView, self).dispatch(*args, **kwargs)
+
+    def get(self, request, mapid):
         try:
-            game_map = Map.objects.get(id=map_id)
-            return HttpResponse(json.dumps({
-                'success': True, 
-                'map_id' : game_map.id, 
-                'map_data': game_map.data, #send the string
-                }), mimetype='application/json')
-        except Map.DoesNotExist:
-            return HttpResponse(json.dumps({
+            mapid = int(mapid)
+        except ValueError:
+            return json_response({
                 'success': False,
                 'reason': "No map exists with given map id!"
-                }), mimetype='application/json')
+            })
 
-    elif request.method == 'POST':
-        if 'map_id' not in request.POST:
-            map_id = "";
-        else:
-            map_id = request.POST['map_id'];
+        try:
+            game_map = Map.objects.get(id=mapid)
+            return json_response({
+                'success': True,
+                'map_id': game_map.id,
+                'map_data': game_map.data,  # send the string
+            })
 
-        if not map_id:
-            creator = request.user
-            num_players = 2 #uh oh
-            map_name = "qwer"
-            game_map = Map(
-                    creator=creator,
-                    num_players=num_players,
-                    data=request.POST['map_data'], #gets stored as a string
-                    map_name=map_name
-                    )
+        except Map.DoesNotExist:
+            return json_response({
+                'success': False,
+                'reason': "No map exists with given map id!"
+            })
 
-            # import logging
-            # logger = logging.getLogger("socketio")
-            # logger.critical(game_map)
+    def post(self, request, mapid):
+        try:
+            mapid = int(mapid)
+        except ValueError:
+            return json_response({
+                'success': False,
+                'reason': "No map exists with given map id!"
+            })
 
-        else:
-            try:
-                game_map = Map.objects.get(id=map_id)
-                game_map.data = request.POST['map_data']
-            except Map.DoesNotExist:
-                return HttpResponse(json.dumps({
-                    'success': False,
-                    'reason': "No map exists with given map id!"
-                    }), mimetype='application/json')
+        try:
+            game_map = Map.objects.get(id=mapid)
+            game_map.data = request.POST['map_data']
+        except Map.DoesNotExist:
+            return json_response({
+                'success': False,
+                'reason': "No map exists with given map id!"
+            })
 
         game_map.save()
-        return HttpResponse(json.dumps({
+        return json_response({
             'success': True,
-            'map_id' : game_map.id
-            }), mimetype='application/json')
-    else:
-        pass # handle weird verbs
+            'map_id': game_map.id
+        })
 
 
+class NewMapView(View):
+    """
+    Handles all requests that go to /map/
+    """
+
+    http_method_names = ['get', 'post', 'options']
+
+    @csrf_exempt
+    def dispatch(self, *args, **kwargs):
+        return super(NewMapView, self).dispatch(*args, **kwargs)
+
+    def get(self, request):
+        return json_response({
+            'success': False,
+            'reason': "No map id supplied!"
+        })
+
+    def post(self, request):
+        creator = request.user
+        num_players = 2  # uh oh
+        map_name = "qwer"
+        game_map = Map(
+            creator=creator,
+            num_players=num_players,
+            data=request.POST['map_data'],  # gets stored as a string
+            map_name=map_name
+        )
+
+        game_map.save()
+        return json_response({
+            'success': True,
+            'map_id': game_map.id
+        })

--- a/the_game_bazaar/settings.py
+++ b/the_game_bazaar/settings.py
@@ -84,17 +84,25 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    #'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '0882yiey#ov@fih7uuv^$uyy_5@g^j(m7_0gbkx*%ql#w)-)@z'
 
+LOGIN_URL = '/'
+LOGIN_EXEMPT_URLS = [
+    r'^auth/',
+    r'^static/',
+    r'^jasmine/',
+    'login/'
+]
+
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
+    #'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -103,6 +111,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'lib.middleware.LoginRequiredMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/the_game_bazaar/static/the_game_bazaar/js/play.js
+++ b/the_game_bazaar/static/the_game_bazaar/js/play.js
@@ -1,127 +1,21 @@
-
-function getLobbyTable(){
-	html = '';
-	$.ajax({
-	    type: "GET",
-	    async: false,
-	    url: "/ajax/lobby/",
-	    headers: {
-	        "X-CSRFToken": $.cookie('csrftoken')
-	    },
-	    success: function (data){
-			//open table	    	
-	    	html += "<table class='table table-striped'>";
-	    	//table headers
-	    	html += "<thead><tr>";
-        	html += "<th>Game ID</th>";
-        	html += "<th>Map Name</th>";
-        	html += "<th>Players</th>";
-            html += "<th></th>";
-       		html += "</tr></thead><tbody>";
-       		//iterator down data and get stuff
-       		for (var i = 0; i < data.length; i++){
-       			var game = data[i];
-       			html += "<tr>\
-                            <td>"+game.id+"</td>\
-                            <td>"+game.map_name+"</td>\
-                            <td>"+printPlayers(game.players)+"</td>\
-                            <td>\
-                                <form action='/game/join' method='POST' style='margin:0px'>\
-                                    <div style='display:none'><input name='csrfmiddlewaretoken' type='hidden' value='"+$.cookie('csrftoken')+"'></div>\
-                                    <input name='game-id' type='hidden' value='"+game.id+"'/>\
-                                    <button class='btn'>Join</button>\
-                                </form>\
-                            </td>\
-                        </tr>";
-			}
-
-       		//close table
-	    	html += "</tbody></table>";
-	    }
-	});
-	return html;
-};
-
-function getHostTable(){
-	html = '';
-	$.ajax({
-	    type: "GET",
-	    async: false,
-	    url: "/ajax/maps/",
-	    headers: {
-	        "X-CSRFToken": $.cookie('csrftoken')
-	    },
-	    success: function (data){
-	    	console.log(data);
-			html += "<table class='table table-striped'>\
-                        <thead><tr>\
-                                <th>Map ID</th>\
-                                <th>Map Name</th>\
-                                <th># of players</th>\
-                                <th></th>\
-                        </tr></thead>\
-                        <tbody>"
-       		for (var i = 0; i < data.length; i++){
-       			var map = data[i];
-       			html += "<tr>\
-                            <td>"+map.id+"</td>\
-                            <td>"+map.name+"</td>\
-                            <td>"+map.max_players+"</td>\
-                            <td>\
-                                <form action='/game/host' method='POST' style='margin:0px'>\
-                                    <div style='display:none'><input name='csrfmiddlewaretoken' type='hidden' value='"+$.cookie('csrftoken')+"'></div>\
-                                    <input name='map-id' type='hidden' value='"+map.id+"'/>\
-                                    <button class='btn'>Host</button>\
-                                </form>\
-                            </td>\
-                        </tr>";
-			}
-
-       		//close table
-	    	html += "</tbody></table>";
-	    }
-	});
-	return html;
+function showHost() {
+    $('#play-host').show();
+    $('#play-join').hide();
 }
 
-function showHost(){
-	$('#play-host').show();
-	$('#play-join').hide();
-};
+function showPlay() {
+    $('#play-host').hide();
+    $('#play-join').show();
+}
 
-function showPlay(){
-	$('#play-host').hide();
-	$('#play-join').show();
-};
+$().ready(function() {
+    $('#play-host').hide();
 
-function printPlayers(json_players){
-	var html = '';
-	for (var key in json_players){
-		var player = json_players[key];
-		if (player !== ""){
-			html += json_players[key] + ', ';
-		}
-	}
-	html = html.slice(0,-2);
-	return html;
-};
+    $('#play-host-button').click(function(){
+        showHost();
+    });
 
-$().ready(function(){
-	$('#play-host').hide();
-
-	$('#play-host-button').click(function(){
-		showHost();
-	});
-
-	$('#play-join-button').click(function(){
-		showPlay();
-	});
-
-	$('#play-join-table').html(function(){
-		return getLobbyTable();
-	});
-
-	$('#play-host-table').html(function(){
-		return getHostTable();
-	});
+    $('#play-join-button').click(function(){
+        showPlay();
+    });
 });

--- a/the_game_bazaar/templates/the_game_bazaar/home.html
+++ b/the_game_bazaar/templates/the_game_bazaar/home.html
@@ -16,12 +16,12 @@
             <div class="span10">
                 <div class="row">
                     <div class="span5">
-                        <form action="/play" method="get">
+                        <form action="{% url lobbies_view %}" method="get">
                             <input type="submit" value="Play a Game!"></input>
                         </form>
                     </div>
                     <div class="span5">
-                        <form action="/edit" method="get">
+                        <form action="{% url edit %}" method="get">
                             <input type="submit" value="Edit a Map!"></input>
                         </form>
                     </div>

--- a/the_game_bazaar/templates/the_game_bazaar/play.html
+++ b/the_game_bazaar/templates/the_game_bazaar/play.html
@@ -17,12 +17,66 @@
                 <div id="play-join">
                     <button id="play-host-button" class="btn btn-primary pull-right">Host a Game</button>
                     <h3>Join A Game:</h3>
-                    <div id="play-join-table"></div>
+                    <div id="play-join-table">
+                        <table class='table table-striped'>
+                            <thead>
+                                <tr>
+                                    <th>Game ID</th>
+                                    <th>Map Name</th>
+                                    <th>Players</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for game in games %}
+                                <tr>
+                                    <td>{{ game.id }}</td>
+                                    <td>{{ game.map_name }}</td>
+                                    <td>
+                                    {% for player in game.players %}
+                                        {{ player }},
+                                    {% endfor %}
+                                    </td>
+                                    <td>
+                                        <a href="{% url game_view game.id %}" class='btn'>Join</a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                            </table>
+                    </div>
                 </div>
                 <div id="play-host">
                     <button id="play-join-button" class="btn btn-primary pull-right">Join a Game</button>
                     <h3>Host A Game:</h3>
-                    <div id="play-host-table"></div>
+                    <div id="play-host-table">
+                        <table class='table table-striped'>
+                            <thead>
+                                <tr>
+                                    <th>Map ID</th>
+                                    <th>Map Name</th>
+                                    <th># of players</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for map in maps %}
+                                <tr>
+                                    <td>{{ map.id }}</td>
+                                    <td>{{ map.name }}</td>
+                                    <td>{{ map.max_players }}</td>
+                                    <td>
+                                        <form action='/game/' method='POST' style='margin:0px'>
+                                            {% csrf_token %}
+                                            <input name='map_id' type='hidden' value='{{ map.id }}'/>
+                                            <button class='btn'>Host</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/the_game_bazaar/urls.py
+++ b/the_game_bazaar/urls.py
@@ -1,23 +1,27 @@
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf.urls import patterns, include, url
 from the_game_bazaar import views
-from lib.views import get_map
 from jasmine_testing.views import tests
+import lib.sdjango
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns('',
+lib.sdjango.autodiscover()
+
+urlpatterns = patterns(
+    '',
     url(r'^$',
         views.index,
         name="index"),
 
-    url(r'^socket.io/', include('game.urls')),
+    url(r'^socket\.io', include(lib.sdjango.urls)),
 
     url(r'^home/$',
         views.home,
         name="home"),
+
     # User menu items
     url(r'^user/admin$',
         views.user_admin,
@@ -26,7 +30,7 @@ urlpatterns = patterns('',
     url(r'^user/history$',
         views.user_history,
         name="user_history"),
-    
+
     # Ajax Calls
     url(r'^ajax/lobby/$',
         views.ajax_lobby_games,
@@ -39,7 +43,7 @@ urlpatterns = patterns('',
     url(r'^ajax/gravatar/$',
         views.ajax_gravatar,
         name="ajax_gravatar"),
-    
+
     # Loggin In, Registering, Loggin Out
     url(r'^login/$',
         views.login,
@@ -62,10 +66,6 @@ urlpatterns = patterns('',
         name="ajax_change"),
 
     # Game related
-    url(r'^play/$',
-        views.play,
-        name="play"),
-
     url(r'^edit/$',
         views.edit,
         name="edit"),
@@ -77,7 +77,7 @@ urlpatterns = patterns('',
     url(r'^jasmine/$', tests, name="tests"),
 
     # Retrieving and saving maps
-    url(r'^map/$', get_map, name="get_map"),
+    url(r'^map/', include('lib.urls'))
 
 
     # Examples:

--- a/the_game_bazaar/views.py
+++ b/the_game_bazaar/views.py
@@ -13,6 +13,7 @@ from django.db import IntegrityError
 import hashlib
 import urllib
 
+
 # /
 def index(request):
     context = {
@@ -25,24 +26,12 @@ def index(request):
 
 
 # /home
-@login_required(login_url='/', redirect_field_name=None)
 def home(request):
     context = {}
     return render(request, 'the_game_bazaar/home.html', context)
 
 
-# /play
-@login_required(login_url='/', redirect_field_name=None)
-def play(request):
-    context = {
-        "maps": Map.objects.all(),
-        "lobby_games": Game.get_games_in_state(Game.LOBBY).order_by('id').reverse(),
-    }
-    return render(request, 'the_game_bazaar/play.html', context)
-
-
 # /edit
-@login_required(login_url='/', redirect_field_name=None)
 def edit(request):
     context = {
         "user": request.user,
@@ -52,20 +41,20 @@ def edit(request):
 
 
 # /list
-def list_games(request):
-    context = {
-    }
-    return render(request, 'the_game_bazaar/play.html', context)
+# What does this even do?
+# def list_games(request):
+#   context = {
+#   }
+#   return render(request, 'the_game_bazaar/play.html', context)
 
 # /user stuff
-@login_required(login_url='/', redirect_field_name=None)
 def user_admin(request):
     context = {
-        "user":request.user,
+        "user": request.user,
     }
     return render(request, 'the_game_bazaar/user_admin.html', context)
 
-@login_required(login_url='/', redirect_field_name=None)
+
 def user_history(request):
     games = Game.objects.all()
     owned_games = []
@@ -75,14 +64,15 @@ def user_history(request):
             owned_games.append(game)
 
     context = {
-        "user":request.user,
+        "user": request.user,
         "games": owned_games,
     }
     return render(request, 'the_game_bazaar/user_history.html', context)
+
+
 ###############################################################################
 # AJAX
 ###############################################################################
-@login_required(login_url='/', redirect_field_name=None)
 def ajax_lobby_games(request):
     game_list = []
     games = Game.get_games_in_state(Game.LOBBY).order_by('id').reverse()
@@ -90,7 +80,7 @@ def ajax_lobby_games(request):
         game_list.append(game.to_map())
     return HttpResponse(json.dumps(game_list), mimetype="application/json")
 
-@login_required(login_url='/', redirect_field_name=None)
+
 def ajax_maps(request):
     map_list = []
     maps = Map.objects.all()
@@ -98,7 +88,7 @@ def ajax_maps(request):
         map_list.append(a_map.to_map())
     return HttpResponse(json.dumps(map_list), mimetype="application/json")
 
-@login_required(login_url='/', redirect_field_name=None)
+
 def ajax_gravatar(request):
     email = request.user.email
     size = 40
@@ -108,19 +98,19 @@ def ajax_gravatar(request):
         email = request.GET['email']
 
     gravatar_url = "<img src='http://www.gravatar.com/avatar/" + hashlib.md5(email.lower()).hexdigest() + "?"
-    gravatar_url += urllib.urlencode({'s':str(size)})
+    gravatar_url += urllib.urlencode({'s': str(size)})
     gravatar_url += "' />"
     return HttpResponse(gravatar_url, mimetype="text/html")
 
+
 ###############################################################################
-# AUTHENTICATION 
+# AUTHENTICATION
 ###############################################################################
-@login_required(login_url='/', redirect_field_name=None)
 def login(request):
     context = {}
     return render(request, 'the_game_bazaar/login.html', context)
 
-@login_required(login_url='/', redirect_field_name=None)
+
 @require_http_methods(["POST"])
 def ajax_change(request):
     resp = {
@@ -147,6 +137,7 @@ def ajax_change(request):
         resp['error'] = 'Please fill out all the fields. They are all necessary'
 
     return HttpResponse(json.dumps(resp), mimetype="application/json")
+
 
 @require_http_methods(["POST"])
 def ajax_login(request):


### PR DESCRIPTION
Tons of changes were made to the website interface:
- Changed all (I hope) instances of urls to use reverse() for looking up the API
- Accessing the list of games is now GET /game/
- Accessing a game with id {gameid} is now GET /game/{gameid}
- Accessing a map with id {mapid} is now GET /map/{mapid}
- Saving a map to {mapid} is now POST /map/{mapid}
- Saving a new map without a {mapid} is now POST /map/
- gamens.py is now sockets.py (if gevent-socketio gets updated, this will be compatible with the future version)
- game.views and map.views now contain class-based views, which makes it easier to separate GET and POST requests and handle edge cases
- Moved Game controller methods to models.py, which makes them easier to test
- Removed all of the login_required decorators, since it was very repetitive
- Added LoginRequiredMiddleware, which basically puts login_required on every request except the ones specified in settings.LOGIN_EXEMPT_URLS (which can handle regexps) and settings.LOGIN_URL
- Tests were modified to support the new API
- Changed the jasmine tests to use the new api (although the tests correctly use the api, it is unable to access the website because the new login required middleware redirects it back to the homepage)
- Aborted writing tests for the new API... the map URLs were already tested pretty thoroughly as far as I know and the game views are hard to test.
